### PR TITLE
Create test simulation for DOS 5 overload

### DIFF
--- a/user-files/simulations/dos5ApplicationOverload.scala
+++ b/user-files/simulations/dos5ApplicationOverload.scala
@@ -18,7 +18,7 @@ import dos5Application.AdditionalGets.additional_gets
  */
 class Dos5ApplicationOverload extends Simulation {
   val httpProtocol = http
-    .baseUrl("http://localhost/")
+    .baseUrl("https://www.staging.marketplace.team/")
     .inferHtmlResources(BlackList(""".*\.js""", """.*\.css""", """.*\.gif""", """.*\.jpeg""", """.*\.jpg""", """.*\.ico""", """.*\.woff""", """.*\.(t|o)tf""", """.*\.png""", """.*\.woff2""", """.*detectportal\.firefox\.com.*"""), WhiteList())
     .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
     .acceptEncodingHeader("gzip, deflate")


### PR DESCRIPTION
Trello: https://trello.com/c/kGmsXWZ1/520-3-find-out-whether-dmp-can-cope-with-dos5-closing

We want to find out how DMp performs when faced with 4x to 6x predicted traffic. Start at 4x, ramp up to 6x over 60 minutes, and then stay there for 30 minutes.

See the load testing plan for an explanation of the numbers: https://docs.google.com/document/d/1LMKq2PlhIuDiXEiOVv7wlqctVpWjQFLpD4pG6VqAh5Y (GDS-only).